### PR TITLE
remove trailing slash from #57

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@
       <a class="site" target="blank" href="https://robbie.antenesse.net/">robbie.antenesse.net</a>
     </li>
 
-    <li> <span class="before-blue" style="--data-size:374.2;"></span> <span class="after">374.2 KB</span> <a class="site" target="blank" href="https://www.drgomesp.dev/">drgomesp.dev/</a>
+    <li> <span class="before-blue" style="--data-size:374.2;"></span> <span class="after">374.2 KB</span> <a class="site" target="blank" href="https://www.drgomesp.dev/">drgomesp.dev</a>
     </li>
 
     <li>


### PR DESCRIPTION
'T was the only entry with a trailing slash in the link label
as displayed on the site.

Follows-up 62a525da5c5005.