### PR TITLE
Fixed cyber-diocletian.github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@
     <li>
       <span class="before" style="--data-size:47.3;"></span>
       <span class="after">47.3kb</span>
-      <a class="site" target="blank" href="https://cyber-diocletian.github.io/">cyber-diocletian.github.io/</a>
+      <a class="site" target="blank" href="https://cyber-diocletian.github.io/">cyber-diocletian.github.io</a>
     </li>
 
     <li>


### PR DESCRIPTION
Remove trailing slash that no other link has in its label.
 
Ref https://github.com/kevquirk/512kb.club/issues/71