### PR TITLE
fixed URL for bnolet.me

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,7 +634,7 @@
   <li>
       <span class="before" style="--data-size:180.3;"></span>
       <span class="after">180.3 KB</span>
-      <a class="site" target="blank" href="https://example.com">bnolet.me</a>
+      <a class="site" target="blank" href="https://bnolet.me">bnolet.me</a>
     </li>
 
    <li>


### PR DESCRIPTION
Corrected URL for bnolet.me which was pointing to example.com