### PR TITLE
updated adrsrv.duckdns.org domain and size

### DIFF
--- a/_data/green-team.yml
+++ b/_data/green-team.yml
@@ -33,11 +33,6 @@
   size: 2.8
   last_checked:
 
-- domain: adrsrv.duckdns.org
-  url: https://adrsrv.duckdns.org
-  size: 3.1
-  last_checked:
-
 - domain: kishvanchee.com
   url: https://kishvanchee.com
   size: 3.1
@@ -127,6 +122,10 @@
   url: https://aboutdavid.me
   size: 5
   last_checked:
+  
+- domain: groundzeno.net
+  url: https://groundzeno.net
+  size: 5.1TheOnAndOnlyZenomat/512kb.club
 
 - domain: bestmotherfucking.website
   url: https://bestmotherfucking.website

--- a/_data/green-team.yml
+++ b/_data/green-team.yml
@@ -122,10 +122,6 @@
   url: https://aboutdavid.me
   size: 5
   last_checked:
-  
-- domain: groundzeno.net
-  url: https://groundzeno.net
-  size: 5.1TheOnAndOnlyZenomat/512kb.club
 
 - domain: bestmotherfucking.website
   url: https://bestmotherfucking.website
@@ -221,6 +217,11 @@
   url: https://mizik.sk
   size: 8.1
   last_checked:
+
+- domain: groundzeno.net
+  url: https://groundzeno.net
+  size: 8.3
+  last_checked: 2021-05-25
 
 - domain: paritybit.ca
   url: https://paritybit.ca


### PR DESCRIPTION
I changed my domain, so I am updating my entry here.
GT-Matrix scan: https://gtmetrix.com/reports/groundzeno.net/cMXXzynz/
I subtracted the green-team badge, so we go from 8.3kb uncompressed to 5.1kb.