### PR TITLE
Updated dn15.de

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -324,9 +324,9 @@
   last_checked: 2021-05-18
 
 - domain: dn15.de
-  url: https://dn15.de//
-  size: 459.6
-  last_checked: 2021-05-17
+  url: https://dn15.de/
+  size: 215.9
+  last_checked: 2021-05-31
 
 - domain: docs.j7k6.org
   url: https://docs.j7k6.org/


### PR DESCRIPTION
https://gtmetrix.com/reports/dn15.de/g8Prq0i2/

- domain: dn15.de
  url: https://dn15.de/
  size: 215.9
  last_checked: 2021-05-31