### PR TITLE
Update karamoff.dev

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -697,7 +697,7 @@
   url: https://luana.cc/
   size: 22.1
   last_checked: 2021-05-21
-  
+
 - domain: lukesempire.com
   url: https://lukesempire.com/
   size: 78.8

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -629,9 +629,9 @@
   last_checked: 2021-05-17
 
 - domain: karamoff.dev
-  url: https://karamoff.dev//
-  size: 94.7
-  last_checked: N/A
+  url: https://karamoff.dev/
+  size: 50.4
+  last_checked: 2021-06-05
 
 - domain: karl.berlin
   url: https://www.karl.berlin/


### PR DESCRIPTION
Dropped size from 94.7 KB to 50.4 KB

Link to GTMetrix results: https://gtmetrix.com/reports/karamoff.dev/BnJgsbfi/