### PR TITLE
Update sites.yaml - timotijhof.net

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1245,8 +1245,8 @@
 
 - domain: timotijhof.net
   url: https://timotijhof.net/
-  size: 37
-  last_checked: N/A
+  size: 35.3
+  last_checked: 2021-06-10
 
 - domain: tokiesan.github.io
   url: https://tokiesan.github.io/


### PR DESCRIPTION
As of 10 June 2021, uncompressed total is 35.3 KB.

https://gtmetrix.com/reports/timotijhof.net/RJnBXbX9/#waterfall