### PR TITLE
added blog.larsgerber.ch

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -172,6 +172,11 @@
   url: https://blog.khaleelgibran.com//
   size: 216.9
   last_checked: 2021-05-17
+  
+- domain: blog.larsgerber.ch
+  url: https://blog.larsgerber.ch/
+  size: 159.2
+  last_checked: 2021-06-16
 
 - domain: blog.mooreanalysis.com
   url: https://blog.mooreanalysis.com/


### PR DESCRIPTION
Landing page: blog.larsgerber.ch (159 KB) | https://gtmetrix.com/reports/blog.larsgerber.ch/XPdCpvUa/
Biggest page (14 images, 502 KB) | https://gtmetrix.com/reports/blog.larsgerber.ch/y9y5CExh/