### PR TITLE
Fix minor typo in the FAQ

### DIFF
--- a/_includes/faq-07.html
+++ b/_includes/faq-07.html
@@ -12,7 +12,7 @@
 
     <p>The aim of The 512KB Club is to showcase lightweight websites. Anyone can create a website that is under 1KB, but composed only of a single h1 tag and a couple of links. That's boring - try and be more interesting.</p>
 
-    <h2>Illegal or inappropriate conent</h2>
+    <h2>Illegal or inappropriate content</h2>
 
     <p>This can be anything we deem inappropriate for the 512KB Club. Things like pornographic sites, or sites that contain NSFW material will not be added. Basically, if you wouldn't show it to your grandma or your kids, you're probably not going to get accepted.</p>
 


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [x] Website code changes
- [ ] Other not listed

I believe it should be "Illegal or inappropriate _content_" in the FAQ, not "Illegal or inappropriate _conent_"