### PR TITLE
Update sites.yml

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1437,3 +1437,9 @@
   url: https://zwieratko.sk/
   size: 27
   last_checked: 2021-05-18
+  
+- domain: scf37.me
+  url: https://scf37.me/tools/base64-decoder/
+  size: 96.8
+  last_checked: 2021-07-14
+


### PR DESCRIPTION
Report: https://gtmetrix.com/reports/scf37.me/pTiGRXSj/

Home page is no fun, it is only 30+ kb. 

- domain: scf37.me
  url: https://scf37.me/tools/base64-decoder/
  size: 96.8
  last_checked: 2021-07-14