### PR TITLE
Update size for web.koyu.space

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1360,8 +1360,8 @@
 
 - domain: web.koyu.space
   url: https://web.koyu.space
-  size: 285.8
-  last_checked: 2021-07-11
+  size: 369.0
+  last_checked: 2021-07-20
 
 - domain: weinzierlweb.com
   url: https://weinzierlweb.com/


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: web.koyu.space
  url: https://web.koyu.space
  size: 369.0
  last_checked: 2021-07-20
```

GTMetrix Report: https://gtmetrix.com/reports/web.koyu.space/YV0uNwVg/
