### PR TITLE
Remove degruchy.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -338,11 +338,6 @@
   size: 31.2
   last_checked: 2021-05-23
 
-- domain: degruchy.org
-  url: https://degruchy.org/
-  size: 3.2
-  last_checked: 2021-05-18
-
 - domain: dejalavidavolar.org
   url: https://dejalavidavolar.org/
   size: 96.1


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [ ] The following information is filled identical to the data file

```
- domain: degruchy.org
  url: https://degruchy.org/
  size: 1380
  last_checked: 2021-07-20
```

GTMetrix Report: https://gtmetrix.com/reports/degruchy.org/5pTEoGHm/
