### PR TITLE
Update size of chriswiegman.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -240,8 +240,8 @@
 
 - domain: chriswiegman.com
   url: https://chriswiegman.com/
-  size: 93.8
-  last_checked: N/A
+  size: 436
+  last_checked: 2021-07-21
 
 - domain: ciboulette.net
   url: https://ciboulette.net/


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: chriswiegman.com
  url: https://chriswiegman.com/
  size: 436
  last_checked: 2021-07-21
```

GTMetrix Report: https://gtmetrix.com/reports/chriswiegman.com/KN7YOxvu/
