### PR TITLE
Remove sitejs.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1178,11 +1178,6 @@
   size: 12.6
   last_checked: 2021-05-18
 
-- domain: sitejs.org
-  url: https://sitejs.org/
-  size: 134
-  last_checked: N/A
-
 - domain: slashdev.space
   url: https://slashdev.space/
   size: 399.9


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [ ] The following information is filled identical to the data file

```
- domain: sitejs.org
  url: https://sitejs.org/
  size: 709
  last_checked: 2021-07-21
```

GTMetrix Report: https://gtmetrix.com/reports/sitejs.org/Ldo3x8oA/
