### PR TITLE
Remove stuts.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1213,11 +1213,6 @@
   size: 190
   last_checked: N/A
 
-- domain: stuts.uk
-  url: http://stuts.uk/
-  size: 212
-  last_checked: N/A
-
 - domain: sugarfi.dev
   url: https://sugarfi.dev/
   size: 32.2


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [ ] The following information is filled identical to the data file

```
- domain: stuts.uk
  url: http://stuts.uk/
  size: 1970
  last_checked: 2021-07-22
```

GTMetrix Report: https://gtmetrix.com/reports/stuts.uk/NBBl3WSj/
