### PR TITLE
recheck/update sizes of several websites

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -36,7 +36,7 @@
 - domain: Phate6660.codeberg.page
   url: https://Phate6660.codeberg.page/
   size: 87.3
-  last_checked: N/A
+  last_checked: 2021-08-07
 
 - domain: a1cy0n.xyz
   url: https://a1cy0n.xyz/
@@ -55,8 +55,8 @@
 
 - domain: adrian.geek.nz
   url: https://adrian.geek.nz/
-  size: 159.9
-  last_checked: N/A
+  size: 160
+  last_checked: 2021-08-07
 
 - domain: airikr.me
   url: https://airikr.me/
@@ -75,8 +75,8 @@
 
 - domain: allien.work
   url: https://allien.work/
-  size: 178.5
-  last_checked: N/A
+  size: 166
+  last_checked: 2021-08-07
 
 - domain: amanasifkhalid.github.io
   url: https://amanasifkhalid.github.io/
@@ -135,13 +135,13 @@
 
 - domain: beh.uk
   url: https://www.beh.uk/
-  size: 88.1
-  last_checked: N/A
+  size: 102
+  last_checked: 2021-08-07
 
 - domain: benpro.fr
   url: https://benpro.fr/
-  size: 205.1
-  last_checked: N/A
+  size: 230
+  last_checked: 2021-08-07
 
 - domain: bestmotherfucking.website
   url: https://bestmotherfucking.website/
@@ -155,8 +155,8 @@
 
 - domain: binyam.in
   url: https://binyam.in/
-  size: 93.8
-  last_checked: N/A
+  size: 28.8
+  last_checked: 2021-08-07
 
 - domain: block.sunappu.net
   url: https://block.sunappu.net/
@@ -180,8 +180,8 @@
 
 - domain: blog.dgold.eu
   url: https://blog.dgold.eu/
-  size: 78.5
-  last_checked: N/A
+  size: 11.6
+  last_checked: 2021-08-07
 
 - domain: blog.khaleelgibran.com
   url: https://blog.khaleelgibran.com/
@@ -200,13 +200,13 @@
 
 - domain: bnolet.me
   url: https://bnolet.me/
-  size: 180.3
-  last_checked: N/A
+  size: 180
+  last_checked: 2021-08-07
 
 - domain: brainbaking.com
   url: https://brainbaking.com/
-  size: 248.4
-  last_checked: N/A
+  size: 251
+  last_checked: 2021-08-07
 
 - domain: brajeshwar.com
   url: https://brajeshwar.com
@@ -220,8 +220,8 @@
 
 - domain: caliandro.de
   url: https://caliandro.de/
-  size: 134.9
-  last_checked: N/A
+  size: 202
+  last_checked: 2021-08-07
 
 - domain: calibratemedia.ca
   url: https://calibratemedia.ca/
@@ -230,18 +230,18 @@
 
 - domain: cameron.otsuka.haus
   url: https://cameron.otsuka.haus/
-  size: 105.3
-  last_checked: N/A
+  size: 105
+  last_checked: 2021-08-07
 
 - domain: canistop.net
   url: https://canistop.net/
-  size: 160.1
-  last_checked: N/A
+  size: 189
+  last_checked: 2021-08-07
 
 - domain: canwe.dev
   url: https://canwe.dev/
-  size: 84.6
-  last_checked: N/A
+  size: 87.0
+  last_checked: 2021-08-07
 
 - domain: chriswiegman.com
   url: https://chriswiegman.com/
@@ -255,8 +255,8 @@
 
 - domain: ciboulette.net
   url: https://ciboulette.net/
-  size: 247.7
-  last_checked: N/A
+  size: 204
+  last_checked: 2021-08-07
 
 - domain: citizen428.net
   url: https://citizen428.net/
@@ -270,8 +270,8 @@
 
 - domain: clubhouse.boxpiper.com
   url: https://clubhouse.boxpiper.com/
-  size: 119.7
-  last_checked: N/A
+  size: 120
+  last_checked: 2021-08-07
 
 - domain: cmdln.org
   url: https://cmdln.org
@@ -280,8 +280,8 @@
 
 - domain: codetheweb.blog
   url: https://codetheweb.blog/
-  size: 174.7
-  last_checked: N/A
+  size: 175
+  last_checked: 2021-08-07
 
 - domain: codevoid.de
   url: https://codevoid.de/
@@ -316,7 +316,7 @@
 - domain: cyber-diocletian.github.io
   url: https://cyber-diocletian.github.io/
   size: 47.3
-  last_checked: N/A
+  last_checked: 2021-08-07
 
 - domain: cyberarm.dev
   url: https://cyberarm.dev/
@@ -325,8 +325,8 @@
 
 - domain: cycloneblaze.net
   url: https://cycloneblaze.net/
-  size: 41.9
-  last_checked: N/A
+  size: 44.4
+  last_checked: 2021-08-07
 
 - domain: dafne.cc
   url: https://dafne.cc/
@@ -345,8 +345,8 @@
 
 - domain: davidrutland.com
   url: https://davidrutland.com/
-  size: 164
-  last_checked: N/A
+  size: 167
+  last_checked: 2021-08-07
 
 - domain: decentnet.github.io
   url: https://decentnet.github.io/
@@ -522,7 +522,7 @@
   url: http://freyx.co/
   size: 260
   last_checked: 2021-08-06
-  
+
 - domain: funnylookinhat.com
   url: https://funnylookinhat.com/
   size: 4.9


### PR DESCRIPTION
Hi again,
This is Aleksei from https://github.com/kevquirk/512kb.club/issues/386 :)

Instead of running Chrome myself and trying to make results match those on GTmetrix, I decided to make a script which uses GTmetrix API to request tests, and processes output.

On a free tier their API allows checking 14 websites per day, so I'm planning to add this script to crontab to run it daily, and make a weekly PR updating 98 of oldest websites.

This PR updates 19 websites, reports for which I requested during testing. Also see a table at the end of this PR for overview of changes.

---

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

Site | old size (team) | new size (team) | delta (%) | GTMetrix | note
---- | --------------- | --------------- | --------- | -------- | ----
[Phate6660.codeberg.page](https://Phate6660.codeberg.page/) | 87.3kb (green) | 87.3kb (green) | +0.0kb (+0%) | [report](https://gtmetrix.com/reports/phate6660.codeberg.page/r5ECBTHT/#waterfall) | 
[adrian.geek.nz](https://adrian.geek.nz/) | 159.9kb (orange) | 160.0kb (orange) | +0.1kb (+0%) | [report](https://gtmetrix.com/reports/adrian.geek.nz/Ccaixb4c/#waterfall) | 
[allien.work](https://allien.work/) | 178.5kb (orange) | 166.0kb (orange) | -12.5kb (-7%) | [report](https://gtmetrix.com/reports/allien.work/CQgttQIX/#waterfall) | 
[beh.uk](https://www.beh.uk/) | 88.1kb (green) | 102.0kb (orange) | +13.9kb (+16%) | [report](https://gtmetrix.com/reports/www.beh.uk/jOSfkHZt/#waterfall) | team changed!!
[benpro.fr](https://benpro.fr/) | 205.1kb (orange) | 230.0kb (orange) | +24.9kb (+12%) | [report](https://gtmetrix.com/reports/benpro.fr/as11qZjd/#waterfall) | big size change!
[binyam.in](https://binyam.in/) | 93.8kb (green) | 28.8kb (green) | -65.0kb (-69%) | [report](https://gtmetrix.com/reports/binyam.in/PYytHKRv/#waterfall) | big size change!
[blog.dgold.eu](https://blog.dgold.eu/) | 78.5kb (green) | 11.6kb (green) | -66.9kb (-85%) | [report](https://gtmetrix.com/reports/blog.dgold.eu/Iutri3hn/#waterfall) | big size change!
[bnolet.me](https://bnolet.me/) | 180.3kb (orange) | 180.0kb (orange) | -0.3kb (-0%) | [report](https://gtmetrix.com/reports/bnolet.me/zBaLTIbp/#waterfall) | 
[brainbaking.com](https://brainbaking.com/) | 248.4kb (orange) | 251.0kb (blue) | +2.6kb (+1%) | [report](https://gtmetrix.com/reports/brainbaking.com/6XGojHDX/#waterfall) | team changed!!
[caliandro.de](https://caliandro.de/) | 134.9kb (orange) | 202.0kb (orange) | +67.1kb (+50%) | [report](https://gtmetrix.com/reports/caliandro.de/knis4arN/#waterfall) | big size change!
[cameron.otsuka.haus](https://cameron.otsuka.haus/) | 105.3kb (orange) | 105.0kb (orange) | -0.3kb (-0%) | [report](https://gtmetrix.com/reports/cameron.otsuka.haus/vyfDhcTP/#waterfall) | 
[canistop.net](https://canistop.net/) | 160.1kb (orange) | 189.0kb (orange) | +28.9kb (+18%) | [report](https://gtmetrix.com/reports/canistop.net/89Yvx3sY/#waterfall) | big size change!
[canwe.dev](https://canwe.dev/) | 84.6kb (green) | 87.0kb (green) | +2.4kb (+3%) | [report](https://gtmetrix.com/reports/canwe.dev/dzTvUZWc/#waterfall) | 
[ciboulette.net](https://ciboulette.net/) | 247.7kb (orange) | 204.0kb (orange) | -43.7kb (-18%) | [report](https://gtmetrix.com/reports/ciboulette.net/YgdeXv2p/#waterfall) | big size change!
[clubhouse.boxpiper.com](https://clubhouse.boxpiper.com/) | 119.7kb (orange) | 120.0kb (orange) | +0.3kb (+0%) | [report](https://gtmetrix.com/reports/clubhouse.boxpiper.com/yRwwJySU/#waterfall) | 
[codetheweb.blog](https://codetheweb.blog/) | 174.7kb (orange) | 175.0kb (orange) | +0.3kb (+0%) | [report](https://gtmetrix.com/reports/codetheweb.blog/1xBnbTx5/#waterfall) | 
[cyber-diocletian.github.io](https://cyber-diocletian.github.io/) | 47.3kb (green) | 47.3kb (green) | +0.0kb (+0%) | [report](https://gtmetrix.com/reports/cyber-diocletian.github.io/QWfCBJI3/#waterfall) | 
[cycloneblaze.net](https://cycloneblaze.net/) | 41.9kb (green) | 44.4kb (green) | +2.5kb (+6%) | [report](https://gtmetrix.com/reports/cycloneblaze.net/qoMNCCzM/#waterfall) | 
[davidrutland.com](https://davidrutland.com/) | 164.0kb (orange) | 167.0kb (orange) | +3.0kb (+2%) | [report](https://gtmetrix.com/reports/davidrutland.com/grJFLoQF/#waterfall) | 

it looks like gtmetrix changed their rounding code since these websites were checked last time - hence, you can see "changes" like for bnolet.me website: from 180.3kb to 180kb which are only a rounding error.