### PR TITLE
Remove sites over 512kb

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -58,11 +58,6 @@
   size: 160
   last_checked: 2021-08-07
 
-- domain: airikr.me
-  url: https://airikr.me/
-  size: 789
-  last_checked: 2021-08-10
-
 - domain: alexey.shpakovsky.ru
   url: http://alexey.shpakovsky.ru/
   size: 91.6
@@ -823,11 +818,6 @@
   size: 183
   last_checked: 2021-08-10
 
-- domain: mcgillij.dev
-  url: https://mcgillij.dev/
-  size: 516
-  last_checked: 2021-08-10
-
 - domain: mees.io
   url: https://mees.io/
   size: 160
@@ -1283,11 +1273,6 @@
   size: 52.8
   last_checked: 2021-08-10
 
-- domain: theandrewbailey.com
-  url: https://theandrewbailey.com/
-  size: 527
-  last_checked: 2021-08-10
-
 - domain: thelion.website
   url: https://thelion.website/
   size: 43.7
@@ -1413,20 +1398,10 @@
   size: 60.8
   last_checked: 2021-05-25
 
-- domain: xpil.eu
-  url: https://xpil.eu/
-  size: 696
-  last_checked: 2021-08-10
-
 - domain: ybad.name
   url: https://ybad.name/
   size: 4.3
   last_checked: 2021-05-18
-
-- domain: yeetpc.com
-  url: https://www.yeetpc.com/
-  size: 532
-  last_checked: 2021-08-10
 
 - domain: yne.fr
   url: https://yne.fr/


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [ ] I used the uncompressed size of the site
- [ ] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [ ] The following information is filled identical to the data file

Site | old size (team) | new size (team) | delta (%) | GTMetrix | note
---- | --------------- | --------------- | --------- | -------- | ----
[airikr.me](https://airikr.me/) | 109.5kb (orange) | 789.0kb (N/A) | +679.5kb (+621) | [report](https://gtmetrix.com/reports/airikr.me/0NnAIexd/#waterfall) | too big for 512kb.club!!!
[mcgillij.dev](https://mcgillij.dev/) | 489.2kb (blue) | 516.0kb (N/A) | +26.8kb (+5) | [report](https://gtmetrix.com/reports/mcgillij.dev/EebRt3T6/#waterfall) | too big for 512kb.club!!!
[theandrewbailey.com](https://theandrewbailey.com/) | 479.0kb (blue) | 527.0kb (N/A) | +48.0kb (+10) | [report](https://gtmetrix.com/reports/theandrewbailey.com/QKf7jkKD/#waterfall) | too big for 512kb.club!!!
[xpil.eu](https://xpil.eu/) | 221.0kb (orange) | 696.0kb (N/A) | +475.0kb (+215) | [report](https://gtmetrix.com/reports/xpil.eu/nvO0P0ET/#waterfall) | too big for 512kb.club!!!
[yeetpc.com](https://www.yeetpc.com/) | 506.3kb (blue) | 532.0kb (N/A) | +25.7kb (+5) | [report](https://gtmetrix.com/reports/www.yeetpc.com/eBc6GsHy/#waterfall) | too big for 512kb.club!!!
