### PR TITLE
Change jamesmck.net to mck.is

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -618,11 +618,6 @@
   size: 183
   last_checked: 2021-08-08
 
-- domain: jamesmck.net
-  url: https://jamesmck.net/
-  size: 57.5
-  last_checked: 2021-08-28
-
 - domain: jds.work
   url: https://jds.work/
   size: 47
@@ -817,6 +812,11 @@
   url: https://www.matthewgraybosch.com/
   size: 183
   last_checked: 2021-08-10
+  
+- domain: mck.is
+  url: https://mck.is/
+  size: 55.6
+  last_checked: 2021-09-03
 
 - domain: mees.io
   url: https://mees.io/


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: mck.is
  url: https://mck.is/
  size: 55.6
  last_checked: 2021-09-03
```

GTMetrix Report: https://gtmetrix.com/reports/mck.is/cRmJHR4f/
