### PR TITLE
added domain hmbrg.xyz

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -582,6 +582,11 @@
   url: https://homburg.xyz
   size: 53.2
   last_checked: 2021-08-07
+  
+- domain: hmbrg.xyz
+  url: https://hmbrg.xyz/
+  size: 1.65
+  last_check: 2021-09-07
 
 - domain: hugo-mechiche.com
   url: https://hugo-mechiche.com/


### PR DESCRIPTION
My other domain (homburg.xyz) can be removed as it's meanwhile used as email-only-domain.

- domain: hmbrg.xyz
  url: https://hmbrg.xyz/
  size: 1.65
  last_check: 2021-09-07

**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: hmbrg.xyz
  url: https://hmbrg.xyz/
  size: 1.65
  last_checked: 2021-09-07
```

GTMetrix Report:
https://gtmetrix.com/reports/hmbrg.xyz/Ya4ywhDv/