### PR TITLE
removed domain homburg.xyz

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -578,11 +578,6 @@
   size: 63.5
   last_checked: 2021-08-31
 
-- domain: homburg.xyz
-  url: https://homburg.xyz/
-  size: 4.0
-  last_checked: 2021-08-29
-
 - domain: hugo-mechiche.com
   url: https://hugo-mechiche.com/
   size: 53.5


### PR DESCRIPTION
because it's no longer use for my website which moved to hmbrg.xyz.

**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [ ] I used the uncompressed size of the site
- [ ] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: homburg.xyz
  url: https://homburg.xyz/
  size: -
  last_checked: -
```

GTMetrix Report:
-