### PR TITLE
add dataswamp.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1378,6 +1378,11 @@
   size: 7.5
   last_checked: 2021-09-24
 
+- domain: webzine.puffy.cafe
+  url: https://webzine.puffy.cafe
+  size: 6.58
+  last_checked: 2021-10-02
+
 - domain: weinzierlweb.com
   url: https://weinzierlweb.com/
   size: 310
@@ -1447,8 +1452,3 @@
   url: https://zwieratko.sk/
   size: 27.1
   last_checked: 2021-08-19
-
-- domain: webzine.puffy.cafe
-  url: https://webzine.puffy.cafe
-  size: 6.58
-  last_checked: 2021-10-02

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -333,6 +333,11 @@
   size: 508
   last_checked: 2021-09-17
 
+- domain: dataswamp.org
+  url: https://dataswamp.org/~solene/
+  size: 74.5
+  last_checked: 2021-10-03
+
 - domain: davidrutland.com
   url: https://davidrutland.com/
   size: 167


### PR DESCRIPTION
This PR is:

- [X] Adding a new domain
- [X] Other not listed

- [X] I used the uncompressed size of the site
- [X] I have included a link to the GTMetrix report
- [X] The domain is in the correct alphabetical order
- [X] This site is not a ultra lightweight site
- [X] The following information is filled identical to the data file

```
- domain: dataswamp.org
  url: https://dataswamp.org/~solene/
  size: 74.5
  last_checked: 2021-10-03
```

GTMetrix Report: https://gtmetrix.com/reports/dataswamp.org/rf3lqCZ2/
