### PR TITLE
add mattwthomas.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -852,6 +852,11 @@
   url: https://www.matthewgraybosch.com/
   size: 33.0
   last_checked: 2021-09-18
+  
+- domain: mattwthomas.com
+  url: https://mattwthomas.com/
+  size: 93.2
+  last_checked: 2021-10-24
 
 - domain: mck.is
   url: https://mck.is/


### PR DESCRIPTION
https://gtmetrix.com/reports/mattwthomas.com/RY96NGct/

**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: mattwthomas.com
  url: https://mattwthomas.com/
  size: 93.2
  last_checked: 2021-10-24
```

GTMetrix Report: https://gtmetrix.com/reports/mattwthomas.com/RY96NGct/
