### PR TITLE
Add buchh.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -203,6 +203,11 @@
   size: 6.4
   last_checked: 2021-10-19
 
+- domain: buchh.org
+  url: https://buchh.org/
+  size: 86
+  last_checked: 2021-11-03
+
 - domain: caliandro.de
   url: https://caliandro.de/
   size: 213


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: buchh.org
  url: https://buchh.org/
  size: 86
  last_checked: 2021-11-03
```

GTMetrix Report: https://gtmetrix.com/reports/buchh.org/5pP6szWy/
