### PR TITLE
Updated aggy.cloud with new size of 189 KB

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -50,8 +50,8 @@
 
 - domain: aggy.cloud
   url: https://aggy.cloud/
-  size: 377
-  last_checked: 2021-10-25
+  size: 189
+  last_checked: 2021-11-04
 
 - domain: alexey.shpakovsky.ru
   url: http://alexey.shpakovsky.ru/


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **189 KB**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: aggy.cloud
  url: https://aggy.cloud/
  size: 189 KB
  last_checked: 2021-11-04
```

GTMetrix Report: https://gtmetrix.com/reports/aggy.cloud/YSAmPfuB/