### PR TITLE
update si3t.ch with new size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1300,8 +1300,8 @@
 
 - domain: si3t.ch
   url: https://si3t.ch/
-  size: 3.9
-  last_checked: 2021-10-02
+  size: 2.36
+  last_checked: 2021-11-17
 
 - domain: simpleblogs.org
   url: https://simpleblogs.org/


### PR DESCRIPTION
This PR is:

- [*] Updating existing domain **size**

```
- domain: si3t.ch
  url: https://si3t.ch
  size: 2.36KB
  last_checked: 2021-11-17
```

GTMetrix Report: https://gtmetrix.com/reports/si3t.ch/8BP30v6J/
