### PR TITLE
https://gtmetrix.com/reports/47nil.com/w0OMh00X/

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1617,3 +1617,8 @@
   url: https://roly.neocities.org/
   size: 32
   last_checked: 2021-11-19
+
+- domain: 47nil.com
+  url: https://47nil.com/
+  size: 111
+  last_checked: 2021-11-22


### PR DESCRIPTION
- domain: 47nil.com
  url: https://47nil.com/
  size: 111
  last_checked: 2021-11-22

https://gtmetrix.com/reports/47nil.com/w0OMh00X/