### PR TITLE
Updated size of gwaymark.co.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -640,8 +640,8 @@
 
 - domain: gwaymark.co.uk
   url: https://www.gwaymark.co.uk
-  size: 7.7
-  last_checked: 2021-11-24
+  size: 11.3
+  last_checked: 2021-11-27
 
 - domain: hashtagueule.fr
   url: https://hashtagueule.fr


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: gwaymark.co.uk
  url: https://www.gwaymark.co.uk
  size: 11.3
  last_checked: 2021-11-27
```

GTMetrix Report:
https://gtmetrix.com/reports/www.gwaymark.co.uk/OPW6inGj/