### PR TITLE
add bvnf.space

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -238,6 +238,11 @@
   size: 86
   last_checked: 2021-11-03
 
+- domain: bvnf.space
+  url: https://bvnf.space/
+  size: 3.06
+  last_checked: 2021-12-18
+
 - domain: caliandro.de
   url: https://caliandro.de/
   size: 213


### PR DESCRIPTION
This PR is:
- [x] Adding a new domain  

---

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: bvnf.space
  url: https://bvnf.space/
  size: 3.06
  last_checked: 2021-12-18
```

GTMetrix Report: https://gtmetrix.com/reports/bvnf.space/zPVWubfO/
