### PR TITLE
Add probably.co.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1188,6 +1188,11 @@
   size: 183
   last_checked: 2021-11-13
 
+- domain: probably.co.uk
+  url: https://probably.co.uk/
+  size: 13.9
+  last_checked: 2021-12-30
+  
 - domain: processwire.dev
   url: https://processwire.dev/
   size: 58.7


### PR DESCRIPTION
https://gtmetrix.com/reports/probably.co.uk/XFVVt9Sa/

**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain:
  url: https://probably.co.uk
  size: 13.9
  last_checked: 2021-12-30
```

GTMetrix Report: https://gtmetrix.com/reports/probably.co.uk/XFVVt9Sa/
