### PR TITLE
add tilde.fun, a friendly tech collective

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1493,6 +1493,11 @@
   size: 460
   last_checked: 2021-12-19
 
+- domain: tilde.fun
+  url: https://tilde.fun/
+  size: 5.22
+  last_checked: 2021-12-31
+
 - domain: timharek.no
   url: https://timharek.no/
   size: 23.6


### PR DESCRIPTION
This PR is:

- [X] Adding a new domain

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [ ] I used the uncompressed size of the site
*actually, I used the compressed size since it's larger for some reason. Didn't seem fair to be further to the top of the list with such a glaring configuration error.*
- [X] I have included a link to the GTMetrix report
- [X] The domain is in the correct alphabetical order
- [X] This site is not a ultra lightweight site
- [X] The following information is filled identical to the data file

```
- domain: tilde.fun
  url: https://tilde.fun/
  size: 5.22
  last_checked: 2021-12-31
```

GTMetrix Report: https://gtmetrix.com/reports/tilde.fun/Y0bWk8j6/
