### PR TITLE
Change URL size of filbertsalim.codeberg.page

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -545,8 +545,8 @@
   
 - domain: filbertsalim.codeberg.page
   url: https://filbertsalim.codeberg.page/
-  size: 240
-  last_checked: 2021-11-30
+  size: 6.7
+  last_checked: 2022-01-05
 
 - domain: format-express.dev
   url: https://format-express.dev/


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: filbertsalim.codeberg.page
  url: https://filbertsalim.codeberg.page/
  size: 6.7
  last_checked: 2022-01-05
```

GTMetrix Report: https://gtmetrix.com/reports/filbertsalim.codeberg.page/JMW0MNCM/
