### PR TITLE
Add camaro96.neocities.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -276,7 +276,7 @@
 - domain: camaro96.neocities.org
   url: https://camaro96.neocities.org/
   size: 10.9
-  last_checked: 2022-11-16
+  last_checked: 2022-01-16
 
 - domain: cameron.otsuka.haus
   url: https://cameron.otsuka.haus/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -275,7 +275,7 @@
 
 - domain: camaro96.neocities.org
   url: https://camaro96.neocities.org/
-  size: 76
+  size: 10.9
   last_checked: 2022-11-16
 
 - domain: cameron.otsuka.haus

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -273,6 +273,11 @@
   size: 162
   last_checked: 2021-12-27
 
+- domain: camaro96.neocities.org
+  url: https://camaro96.neocities.org/
+  size: 76
+  last_checked: 2022-11-16
+
 - domain: cameron.otsuka.haus
   url: https://cameron.otsuka.haus/
   size: 105


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: camaro96.neocities.org
  url: https://camaro96.neocities.org/
  size: 76
  last_checked: 2022-01-16
```

GTMetrix Report: https://gtmetrix.com/reports/camaro96.neocities.org/NjC8ukOF/

I'm unsure if the report should be considered as the main source of truth since all I can see is measuring the main site rather than everything mine that I have (not counting external links such as to archive.org). I believe a better way of measuring is just reporting how much the files I host weigh on my filesystem: 76.0 KB.