### PR TITLE
Update probably.co.uk in sites.yml

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1225,8 +1225,8 @@
 
 - domain: probably.co.uk
   url: https://probably.co.uk/
-  size: 13.9
-  last_checked: 2021-12-30
+  size: 39.0
+  last_checked: 2022-01-17
 
 - domain: processwire.dev
   url: https://processwire.dev/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: probably.co.uk
  url: https://probably.co.uk
  size: 39.0
  last_checked: 2022-01-17
```

GTMetrix Report: https://gtmetrix.com/reports/probably.co.uk/08ua6sZh/
