### PR TITLE
Adding alfie.wtf

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -62,6 +62,11 @@
   url: http://alexey.shpakovsky.ru/
   size: 95.6
   last_checked: 2021-12-23
+  
+- domain: alfie.wtf
+  url: http://www.alfie.wtf
+  size: 19.6
+  last_checked: 2022-01-29
 
 - domain: allaboutberlin.com
   url: https://allaboutberlin.com/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -65,7 +65,7 @@
   
 - domain: alfie.wtf
   url: http://www.alfie.wtf
-  size: 19.6
+  size: 20.4
   last_checked: 2022-01-29
 
 - domain: allaboutberlin.com


### PR DESCRIPTION
I hope I qualify - although my homepage goes against the FAQ (the homepage contains a bunch of links), the entire website i.e all pages linked from the homepage and resources in total comes to (current as of 2022-01-29) 108Kb :)

https://gtmetrix.com/reports/www.alfie.wtf/cAdEHKbd/

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: alfie.wtf
  url: http://www.alfie.wtf
  size: 20.4
  last_checked: 2022-01-29
```

GTMetrix Report: https://gtmetrix.com/reports/www.alfie.wtf/cAdEHKbd/
