### PR TITLE
Update sites.yml

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -443,6 +443,11 @@
   size: 342
   last_checked: 2021-12-28
 
+- domain: deathcult.fun
+  url: https://www.deathcult.fun/ 
+  size: 8.0
+  last_checked: 2022-01-29
+
 - domain: decentnet.github.io
   url: https://decentnet.github.io/
   size: 31.2


### PR DESCRIPTION
Add Internet Death Cult of Fun, 8.02 kB as measured by gtmetrix. A _quality_ internet death cult.

**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [ X ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [ X ] I used the uncompressed size of the site
- [ X ] I have included a link to the GTMetrix report
- [ X ] The domain is in the correct alphabetical order
- [ X ] This site is not a ultra lightweight site
- [ X ] The following information is filled identical to the data file

```
- domain: deathcult.fun
  url: https://www.deathcult.fun/ 
  size: 8.0
  last_checked: 2022-01-29
```

GTMetrix Report:
https://gtmetrix.com/reports/www.deathcult.fun/ccCe4Dcz/
