### PR TITLE
Add brycewray.com to _data/sites.yml

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -282,6 +282,11 @@
   url: https://bruton.tech/
   size: 6.4
   last_checked: 2021-12-23
+  
+- domain: brycewray.com
+  url: https://brycewray.com/
+  size: 128
+  last_checked: 2022-01-31
 
 - domain: buchh.org
   url: https://buchh.org/


### PR DESCRIPTION
GTmetrix result from 2022-01 -31: https://gtmetrix.com/reports/www.brycewray.com/fvJhIYiN/

Shows 128KB uncompressed.

**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

```
- domain: brycewray.com
  url: https://brycewray.com
  size: 128KB
  last_checked: 2022-01-31
```

GTMetrix Report: https://gtmetrix.com/reports/www.brycewray.com/fvJhIYiN/