### PR TITLE
Add elrido.dssr.ch

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -598,6 +598,11 @@
   size: 7.5
   last_checked: 2021-12-09
 
+- domain: elrido.dssr.ch
+  url: https://elrido.dssr.ch/
+  size: 137.5
+  last_checked: 2022-02-05
+
 - domain: emanuelpina.pt
   url: https://emanuelpina.pt/
   size: 175


### PR DESCRIPTION
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] I used the uncompressed size of the site
- [x] I have included a link to the ~GTMetrix~ command line report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: elrido.dssr.ch
  url: https://elrido.dssr.ch/
  size: 137.5
  last_checked: 2022-02-05
```

~GTMetrix~ Yellow Lab Tools Report: https://yellowlab.tools/result/g6rwh5wuha

As per https://github.com/kevquirk/512kb.club/issues/630 I have used an alternative tool for page size measurement because my site is served as `application/xhtml+xml`. As that number seems lower then what I see in Firefox web developer tools as uncompressed size, I instead used the higher number as per the following command line:
```
{ printf 'scale=1;('; LANG=C wget --delete-after -p https://elrido.dssr.ch/ 2>&1 | grep saved | grep -vF robots.txt | cut -d"[" -f 2 | cut -d/ -f 1 | cut -d"]" -f 1 | tr '\n' '+'; printf '0)/1024\n'; } | bc 
137.5
```