### PR TITLE
Updates slitdecision.com entry

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1670,8 +1670,8 @@
 
 - domain: slitdecision.com
   url: https://slitdecision.com/
-  size: 14.8
-  last_checked: 2022-01-16
+  size: 29.9
+  last_checked: 2022-02-21
 
 - domain: solfisher.com
   url: https://solfisher.com/


### PR DESCRIPTION
I'm updating the slitdecision entry, since the site changed. The site is
now a PWA (so has some extra JS) and has an extra icon.
Commit of slitdecision as of now: [f97f8a36a7d01ff2303f8b7bb010896b8e33be4c](https://gitlab.com/RensOliemans/slitdecision/).

GMetrix scan https://gtmetrix.com/reports/slitdecision.com/y3FDwQhk/
shows that it's 29.9KB.
Fun quirk: the uncompressed size (29.9) is
actually _less_ than the compressed size at 30.1KB

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: slitdecision.com
  url: https://slitdecision.com
  size: 29.9
  last_checked: 2022-02-21
```

GTMetrix Report: https://gtmetrix.com/reports/slitdecision.com/y3FDwQhk/
