### PR TITLE
Update g.rmxgrp.dev

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -745,7 +745,7 @@
 
 - domain: g.rmxgrp.dev
   url: https://g.rmxgrp.dev/
-  size: 212
+  size: 82.5
   last_checked: 2022-1-14
 
 - domain: gabnotes.org

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -746,7 +746,7 @@
 - domain: g.rmxgrp.dev
   url: https://g.rmxgrp.dev/
   size: 102
-  last_checked: 2022-01-03
+  last_checked: 2022-03-01
 
 - domain: gabnotes.org
   url: https://gabnotes.org/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -745,8 +745,8 @@
 
 - domain: g.rmxgrp.dev
   url: https://g.rmxgrp.dev/
-  size: 82.5
-  last_checked: 2022-1-14
+  size: 102
+  last_checked: 2022-01-03
 
 - domain: gabnotes.org
   url: https://gabnotes.org/


### PR DESCRIPTION
This PR is:

 

- [ ] Adding a new domain
- [x]  Updating existing domain size
- [ ]  Changing domain name
- [ ]  Removing existing domain from list
- [ ]  Website code changes (512kb.club site)
- [ ]  Other not listed
- [x]  I used the uncompressed size of the site
- [x]  I have included a link to the GTMetrix report
- [x]  The domain is in the correct alphabetical order
- [x]  This site is not a ultra lightweight site
- [x]  The following information is filled identical to the data file

I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.

- [x]  Check to confirm

```
- domain: g.rmxgrp.dev
  url: https://g.rmxgrp.dev/
  size: 102
  last_checked: 2022-02-28 
```

GTMetrix Report:
https://gtmetrix.com/reports/g.rmxgrp.dev/iaptt4lv/