### PR TITLE
Change hunden.kompromis.se to hund.tty1.se

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -883,10 +883,10 @@
   size: 75.9
   last_checked: 2022-01-29
 
-- domain: hunden.linuxkompis.se
-  url: https://hunden.linuxkompis.se/
-  size: 14.7
-  last_checked: 2021-12-13
+- domain: hund.tty1.se
+  url: https://hund.tty1.se/
+  size: 17.8
+  last_checked: 2022-03-11
 
 - domain: i21k.de
   url: https://i21k.de/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: hund.tty1.se
  url: https://hund.tty1.se/
  size: 17.8
  last_checked: 2022-03-11
```

GTMetrix Report: https://gtmetrix.com/reports/hund.tty1.se/Yh7ngCkN/
