### PR TITLE
Added riedler.wien

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1588,6 +1588,11 @@
   size: 46.4
   last_checked: 2021-12-19
 
+- domain: riedler.wien
+  url: http://riedler.wien/music/
+  size: 140
+  last_checked: 2022-03-20
+
 - domain: rishigoomar.com
   url: https://rishigoomar.com/
   size: 474


### PR DESCRIPTION
though I'll probably rewrite the site sometime in summer break. It's hideous and all sort of legacy garbage has been piling up in the backend.

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

Also:

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: riedler.wien
  url: http://riedler.wien/music/
  size: 140
  last_checked: 2022-03-20
```

GTMetrix Report: https://gtmetrix.com/reports/riedler.wien/siK487ZN/
