### PR TITLE
Updated minutestomidnight.co.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1250,8 +1250,8 @@
 
 - domain: minutestomidnight.co.uk
   url: https://minutestomidnight.co.uk
-  size: 159
-  last_checked: 2022-03-17
+  size: 183
+  last_checked: 2022-03-20
 
 - domain: minwiz.com
   url: https://minwiz.com/


### PR DESCRIPTION
Slight increase in uncompressed size.

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: minutestomidnight.co.uk
  url: https://minutestomidnight.co.uk
  size: 183
  last_checked: 2022-03-20
```

GTMetrix Report: https://gtmetrix.com/reports/minutestomidnight.co.uk/vYDQWeN5/
