### PR TITLE
Add 64b.it

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -47,6 +47,11 @@
   url: https://60z.github.io/
   size: 16.2
   last_checked: 2022-03-20
+  
+- domain: 64b.it
+  url: https://64b.it/
+  size: 204
+  last_checked: 2022-03-22
 
 - domain: a1cy0n.xyz
   url: https://a1cy0n.xyz/


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: 64b.it
  url: https://64b.it/
  size: 204
  last_checked: 2022-03-22
```

GTMetrix Report: https://gtmetrix.com/reports/64b.it/Nf8jFCgu/
