### PR TITLE
Add revuo-xmr.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1613,6 +1613,11 @@
   size: 6.93
   last_checked: 2022-04-01
 
+- domain: revuo-xmr.com
+  url: https://revuo-xmr.com/
+  size: 444
+  last_checked: 2022-04-10
+
 - domain: rhapsode.adrian.geek.nz
   url: http://rhapsode.adrian.geek.nz/
   size: 148


### PR DESCRIPTION
Category: Blue Team. 

This PR is:

- [√] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

-----

- [√] I used the uncompressed size of the site
- [√] I have included a link to the GTMetrix report
- [√] The domain is in the correct alphabetical order
- [√] This site is not a ultra lightweight site
- [√] The following information is filled identical to the data file

```
- domain: revuo-xmr.com
  url: https://revuo-xmr.com/
  size: 444
  last_checked: 2022-04-10
```

GTMetrix Report: https://gtmetrix.com/reports/revuo-xmr.com/epfkBmkF/ 