### PR TITLE
Updated size: otgt.us.eu.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1440,8 +1440,8 @@
 
 - domain: otgt.us.eu.org
   url: https://otgt.us.eu.org/
-  size: 57.3
-  last_checked: 2022-04-10
+  size: 70.7
+  last_checked: 2022-04-11
 
 - domain: palashbauri.in
   url: https://palashbauri.in


### PR DESCRIPTION
I added the green team image and some other images to the main page so the size increased.

https://gtmetrix.com/reports/otgt.us.eu.org/ZBXmz7w6/

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain:
  url:
  size:
  last_checked:
```

GTMetrix Report: 
https://gtmetrix.com/reports/otgt.us.eu.org/ZBXmz7w6/