### PR TITLE
Update block.sunappu.net size (now 193 KB)

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -260,8 +260,8 @@
 
 - domain: block.sunappu.net
   url: https://block.sunappu.net/
-  size: 198
-  last_checked: 2021-11-27
+  size: 193
+  last_checked: 2022-04-16
 
 - domain: blog.abbix.me
   url: https://blog.abbix.me/


### PR DESCRIPTION
That’s 5 KB saved!

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: block.sunappu.net
  url: https://block.sunappu.net/
  size: 193
  last_checked: 2022-04-16
```

GTMetrix Report: https://gtmetrix.com/reports/mehdi.cc/26zlB44p/