### PR TITLE
Add melroy.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1293,6 +1293,11 @@
   size: 152
   last_checked: 2022-03-17
 
+- domain: melroy.org
+  url: https://melroy.org
+  size: 38.4
+  last_checked: 2022-05-04
+
 - domain: meribold.org
   url: https://meribold.org/
   size: 19.7


### PR DESCRIPTION
Behold, a nice looking homepage under 40kb! Adding: https://melroy.org.

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed
- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: melroy.org
  url: https://melroy.org
  size: 38.4
  last_checked: 2022-05-04
```

GTMetrix Report: https://gtmetrix.com/reports/melroy.org/cR6woaXE/
