### PR TITLE
Change size for ononoki.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1530,8 +1530,8 @@
   
 - domain: ononoki.org
   url: https://ononoki.org/
-  size: 455
-  last_checked: 2022-05-28
+  size: 93.8
+  last_checked: 2022-05-30
 
 - domain: oscarforner.com
   url: https://oscarforner.com/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: ononoki.org
  url: https://ononoki.org/
  size: 93.8
  last_checked: 2022-05-30
```

GTMetrix Report: https://gtmetrix.com/reports/ononoki.org/HuBwSAR6/
