### PR TITLE
Update size for topikettunen.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2140,8 +2140,8 @@
 
 - domain: topikettunen.com
   url: https://topikettunen.com
-  size: 27.7
-  last_checked: 2022-01-30
+  size: 26.0
+  last_checked: 2022-06-03
 
 - domain: tradingcode.net
   url: https://tradingcode.net/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: topikettunen.com
  url: https://topikettunen.com
  size: 26.0
  last_checked: 2022-06-03
```

GTMetrix Report: https://gtmetrix.com/reports/topikettunen.com/7GYBR8Sv/
