### PR TITLE
Update size for blog.ononoki.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -325,8 +325,8 @@
 
 - domain: blog.ononoki.org
   url: https://blog.ononoki.org/
-  size: 104
-  last_checked: 2022-05-30
+  size: 90.6
+  last_checked: 2022-06-03
 
 - domain: blog.setale.me
   url: https://blog.setale.me/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: blog.ononoki.org
  url: https://blog.ononoki.org/
  size: 90.6
  last_checked: 2022-06-03
```

GTMetrix Report: https://gtmetrix.com/reports/blog.ononoki.org/6qZelHVJ/
