### PR TITLE
Remove theanonymouse.xyz

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2083,11 +2083,6 @@
   size: 53.3
   last_checked: 2022-04-26
 
-- domain: theanonymouse.xyz
-  url: https://theanonymouse.xyz/
-  size: 267
-  last_checked: 2022-05-07
-
 - domain: thejollyteapot.com
   url: https://thejollyteapot.com/
   size: 3.65


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [ ] I used the uncompressed size of the site
- [ ] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: theanonymouse.xyz
  url: https://theanonymouse.xyz/
  size: 267
  last_checked: 2022-05-07
```

The site was added by PR #826.
