### PR TITLE
Add sites 'xlthlx.com' and 'piccioni.london'

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1672,6 +1672,11 @@
   url: https://phreedom.club/
   size: 8.5
   last_checked: 2022-03-18
+  
+- domain: piccioni.london
+  url: https://piccioni.london/
+  size: 374
+  last_checked: 2022-06-27
 
 - domain: plabayo.tech
   url: https://plabayo.tech/
@@ -2332,6 +2337,11 @@
   url: https://xkon.dev/
   size: 6.8
   last_checked: 2022-05-15
+
+- domain: xlthlx.com
+  url: https://xlthlx.com/
+  size: 434
+  last_checked: 2022-06-27
 
 - domain: xslendi.xyz
   url: https://xslendi.xyz/


### PR DESCRIPTION
This PR is:

- *[x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

***

- *[x] I used the uncompressed size of the site
- *[x] I have included a link to the GTMetrix report
- *[x]  The domain is in the correct alphabetical order
- *[x] This site is not a ultra lightweight site
- *[x] The following information is filled identical to the data file

***

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- *[x] Check to confirm

```
- domain: piccioni.london
  url: https://piccioni.london/
  size: 374
  last_checked: 2022-06-27
```

```
- domain: xlthlx.com
  url: https://xlthlx.com/
  size: 434
  last_checked: 2022-06-27
```

GTMetrix Report for piccioni.london: https://gtmetrix.com/reports/piccioni.london/utAlSP03/
GTMetrix Report for xlthlx.com: https://gtmetrix.com/reports/xlthlx.com/YNc05KUD/
