### PR TITLE
domain change small size update matthewthom.as

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1419,7 +1419,7 @@
   last_checked: 2021-12-05
 
 - domain: matthewthom.as
-  url: https://www/matthewthom.as/
+  url: https://www.matthewthom.as/
   size: 87.0
   last_checked: 2022-08-03
 

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1418,10 +1418,10 @@
   size: 5.8
   last_checked: 2021-12-05
 
-- domain: mattwthomas.com
-  url: https://mattwthomas.com/
-  size: 94.0
-  last_checked: 2022-05-15
+- domain: matthewthom.as
+  url: https://www/matthewthom.as/
+  size: 87.0
+  last_checked: 2022-08-03
 
 - domain: mawoka.eu
   url: https://mawoka.eu/


### PR DESCRIPTION
I finally got this new domain. Also a size update. It seems I knocked 1/3 of my page size off somehow in the last few months:
https://gtmetrix.com/reports/www.matthewthom.as/UshNfnVP/

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: matthewthom.as
  url: https://www.matthewthom.as/
  size: 87.0
  last_checked: 2022-08-03
```

GTMetrix Report: https://gtmetrix.com/reports/www.matthewthom.as/UshNfnVP/
