### PR TITLE
updated riedler.wien size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1930,7 +1930,7 @@
 
 - domain: riedler.wien
   url: http://riedler.wien/music/
-  size: 140
+  size: 138
   last_checked: 2022-03-20
 
 - domain: rishigoomar.com

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1931,7 +1931,7 @@
 - domain: riedler.wien
   url: http://riedler.wien/music/
   size: 138
-  last_checked: 2022-03-20
+  last_checked: 2022-08-17
 
 - domain: rishigoomar.com
   url: https://rishigoomar.com/


### PR DESCRIPTION
some of the icons got smaller due to preparations to migrate to the new website (It's going to be near 40KB this time)

(it's still going to be a few months until the new site will be published though. There's multiple subpages I need to finish and I have barely started testing, not to mention my planned server migration.)

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: riedler.wien
  url: http://riedler.wien/music/
  size: 138
  last_checked: 2022-08-17
```

GTMetrix Report: https://gtmetrix.com/reports/riedler.wien/Mjj9gXm4/
