### PR TITLE
Data: update jae.fi size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1135,7 +1135,7 @@
 
 - domain: jae.fi
   url: https://jae.fi/
-  size: 54.1
+  size: 32.2
   last_checked: 2022-02-04
 
 - domain: jakobbouchard.dev

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1136,7 +1136,7 @@
 - domain: jae.fi
   url: https://jae.fi/
   size: 32.2
-  last_checked: 2022-02-04
+  last_checked: 2022-08-24
 
 - domain: jakobbouchard.dev
   url: https://jakobbouchard.dev/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: jae.fi
  url: https://jae.fi/
  size: 32.2
  last_checked: 2022-08-24
```

GTMetrix Report: https://gtmetrix.com/reports/jae.fi/3mD0VheD/
