### PR TITLE
Remove brycewray.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -428,11 +428,6 @@
   size: 6.4
   last_checked: 2022-05-15
 
-- domain: brycewray.com
-  url: https://www.brycewray.com/
-  size: 103.0
-  last_checked: 2022-06-27
-
 - domain: bubble.email
   url: https://bubble.email
   size: 421.0


### PR DESCRIPTION
I believe that my site now is unqualified for this list given the very reasonable explanation in “Ultra minimal / link pages won't be added” on https://512kb.club/faq.

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

(Other items from here on in the boilerplate are irrelevant since I’m asking to **remove** the site.)