### PR TITLE
Add vandenbran.de

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2572,3 +2572,8 @@
   url: https://zwbetz.com/
   size: 67.8
   last_checked: 2022-07-20
+
+- domain: vandenbran.de
+  url: https://vandenbran.de/
+  size: 51.2
+  last_checked: 2022-09-12

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2383,6 +2383,11 @@
   size: 51.6
   last_checked: 2022-05-15
 
+- domain: vandenbran.de
+  url: https://vandenbran.de/
+  size: 51.2
+  last_checked: 2022-09-12
+
 - domain: vegard.net
   url: https://www.vegard.net/
   size: 54.5
@@ -2572,8 +2577,3 @@
   url: https://zwbetz.com/
   size: 67.8
   last_checked: 2022-07-20
-
-- domain: vandenbran.de
-  url: https://vandenbran.de/
-  size: 51.2
-  last_checked: 2022-09-12


### PR DESCRIPTION
This PR is:

- [X] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [X] I used the uncompressed size of the site
- [X] I have included a link to the GTMetrix report
- [X] The domain is in the correct alphabetical order
- [X] This site is not a ultra lightweight site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: vandenbran.de
  url: https://vandenbran.de/
  size: 51.2
  last_checked: 2022-09-12
```

GTMetrix Report: https://gtmetrix.com/reports/vandenbran.de/iqnF2IqE/
