### PR TITLE
Create invalid_site_rechecker.sh

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -862,11 +862,11 @@
   url: http://evantravers.com/
   size: 474
   last_checked: 2022-04-26
-
+  
 - domain: excus.eu
   url: https://excus.eu/
-  size: 407
-  last_checked: 2022-09-17
+  size: 96.5
+  last_checked: 2022-09-24
 
 - domain: extension.ninja
   url: https://www.extension.ninja/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -875,7 +875,7 @@
   
 - domain: excus.eu
   url: https://excus.eu/
-  size: 96.5
+  size: 93.7
   last_checked: 2022-09-24
 
 - domain: extension.ninja

--- a/scripts/invalid_site_rechecker.sh
+++ b/scripts/invalid_site_rechecker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+for f in $(awk -F " " '/url:/ {print $2}' _data/sites.yml)
+do
+  echo $f": "$(curl -o /dev/null -sw "%{response_code}" $f) | grep -v '200\|301\|302\|403' &
+done

--- a/scripts/invalid_site_rechecker.sh
+++ b/scripts/invalid_site_rechecker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 for f in $(awk -F " " '/url:/ {print $2}' _data/sites.yml)
 do
-  echo $f": "$(curl -o /dev/null -sw "%{response_code}" $f) | grep -v '200\|301\|302\|403' &
+  echo $f" Response code: "$(curl -o /dev/null -sw "%{response_code}" $f) | grep -v '200\|301\|302' &
 done

--- a/scripts/invalid_site_rechecker.sh
+++ b/scripts/invalid_site_rechecker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-for f in $(awk -F " " '/url:/ {print $2}' _data/sites.yml)
+for f in $(awk -F " " '/url:/ {print $2}' ../_data/sites.yml)
 do
-  echo $f" Response code: "$(curl -o /dev/null -sw "%{response_code}" $f) | grep -v '200\|301\|302' &
+  echo "Response code: "$(curl -o /dev/null -sw "%{response_code}" $f)" "$f| grep -v '200\|301\|302' 
 done


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [x] Other not listed

I'm proposing a simple, fast script to check the list of sites for invalid HTTP responses. When testing against the sites.yml file from https://github.com/kevquirk/512kb.club/issues/965, it correctly identified 19 of 21 sites with issues (and one of the remaining two sites was deemed to be a non-issue). However, there are some false positives, so using the script will involve manual review.

Side note: I think that some false positives are a natural outcome from the fact that a lot of these sites are self-hosted, feature custom code, and/or are administered by very privacy-conscious people. For example, there four sites currently listed at https://512kb.club return 403 responses to curl, but all of them are in fact accessible - that's why I've omitted any 403 codes from the output, even though I don't think that this is generally a good idea. 