### PR TITLE
Replace rc-lite.xyz with radiocanadamini.ca

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1923,10 +1923,10 @@
   size: 72.1
   last_checked: 2022-03-25
 
-- domain: rc-lite.xyz
-  url: https://rc-lite.xyz/
-  size: 17.6
-  last_checked: 2022-05-15
+- domain: radiocanadamini.ca
+  url: https://radiocanadamini.ca
+  size: 27.3
+  last_checked: 2022-09-30
 
 - domain: rectangles.app
   url: https://rectangles.app/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1893,6 +1893,11 @@
   size: 303
   last_checked: 2022-04-26
 
+- domain: radiocanadamini.ca
+  url: https://radiocanadamini.ca
+  size: 27.3
+  last_checked: 2022-09-30
+
 - domain: raikas.dev
   url: https://raikas.dev/
   size: 4.85
@@ -1922,11 +1927,6 @@
   url: https://rav3ndust.xyz/
   size: 72.1
   last_checked: 2022-03-25
-
-- domain: radiocanadamini.ca
-  url: https://radiocanadamini.ca
-  size: 27.3
-  last_checked: 2022-09-30
 
 - domain: rectangles.app
   url: https://rectangles.app/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: radiocanadamini.ca
  url: https://radiocanadamini.ca
  size: 27.3
  last_checked: 2022-09-30
```

GTMetrix Report: https://gtmetrix.com/reports/radiocanadamini.ca/2p75Vlq5/

I am changing the domain for this site. https://rc-lite.xyz is currently redirecting to https://radiocanadamini.ca, and the latter will be the permanent domain for the project.
