### PR TITLE
Update size of SpaceHey

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2181,7 +2181,7 @@
 - domain: spacehey.com
   url: https://spacehey.com/
   size: 164
-  last_checked: 2022-08-26
+  last_checked: 2022-09-30
 
 - domain: spearfishcap.cap
   url: https://www.spearfishcap.com/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2180,7 +2180,7 @@
 
 - domain: spacehey.com
   url: https://spacehey.com/
-  size: 259
+  size: 164
   last_checked: 2022-08-26
 
 - domain: spearfishcap.cap


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: spacehey.com
  url: https://spacehey.com/
  size: 164
  last_checked: 2022-09-30
```

GTMetrix Report: https://gtmetrix.com/reports/spacehey.com/GdJ5umwQ/

I got the size of the SpaceHey homepage down from 259kb to 164kb. Hope to decrease it even more soon :)
