### PR TITLE
Update size to sulairris.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2230,8 +2230,8 @@
 
 - domain: sulairris.com
   url: https://sulairris.com/
-  size: 328
-  last_checked: 2022-08-01
+  size: 181
+  last_checked: 2022-10-04
 
 - domain: support.tfwnogf.nl
   url: https://support.tfwnogf.nl


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [ ] Check to confirm

```
- domain: sulairris.com
  url: https://sulairris.com/
  size: 181
  last_checked: 2022-10-04
```

GTMetrix Report: https://gtmetrix.com/reports/sulairris.com/gXfLfK18/
