### PR TITLE
Add mobilecoverage.co.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1543,6 +1543,11 @@
   size: 9.8
   last_checked: 2022-05-06
 
+- domain: mobilecoverage.co.uk
+  url: https://www.mobilecoverage.co.uk
+  size: 168
+  last_checked: 2022-10-21
+
 - domain: mogwai.be
   url: https://mogwai.be/
   size: 26.3


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [🗸] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [🗸] I used the uncompressed size of the site
- [🗸] I have included a link to the GTMetrix report
- [🗸] The domain is in the correct alphabetical order
- [🗸] This site is not a ultra lightweight site
- [🗸] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [🗸] Check to confirm

```
- domain: mobilecoverage.co.uk
  url: https://www.mobilecoverage.co.uk
  size: 168
  last_checked: 2022-10-21
```

GTMetrix Report: https://gtmetrix.com/reports/www.mobilecoverage.co.uk/9OR0WqLf/
