### PR TITLE
Add vern.cc to 512kb club

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2507,6 +2507,11 @@
   url: https://www.vegard.net/
   size: 54.5
   last_checked: 2022-02-24
+  
+- domain: vern.cc
+  url: https://vern.cc/
+  size: 21.7
+  last_checked: 2022-12-10
 
 - domain: vidhukant.xyz
   url: https://vidhukant.xyz/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [X] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [X] I used the uncompressed size of the site
- [X] I have included a link to the GTMetrix report
- [X] The domain is in the correct alphabetical order
- [X] This site is not a ultra lightweight site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: vern.cc
  url: https://vern.cc
  size: 21.7
  last_checked: 2022-12-10
```

GTMetrix Report:  https://gtmetrix.com/reports/vern.cc/4Qpzv2Za/