### PR TITLE
Add castorisdead.xyz

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -493,6 +493,11 @@
   size: 414
   last_checked: 2022-11-20
 
+- domain: castorisdead.xyz
+  url: https://castorisdead.xyz
+  size: 194
+  last_checked: 2022-12-12
+
 - domain: catdrout.xyz
   url: https://catdrout.xyz/
   size: 140


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: castorisdead.xyz
  url: https://castorisdead.xyz
  size: 194KB
  last_checked: 2022-12-12
```

GTMetrix Report: <https://gtmetrix.com/reports/castorisdead.xyz/17BW55ov/>
