### PR TITLE
Remove wahyuwiyoko.github.io domain

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2553,11 +2553,6 @@
   size: 7.6
   last_checked: 2022-04-26
 
-- domain: wahyuwiyoko.github.io
-  url: https://wahyuwiyoko.github.io/
-  size: 19.1
-  last_checked: 2022-10-25
-
 - domain: webmusic.pages.dev
   url: https://webmusic.pages.dev/
   size: 505


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [x] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [ ] I used the uncompressed size of the site
- [ ] I have included a link to the GTMetrix report
- [ ] The domain is in the correct alphabetical order
- [ ] This site is not a ultra lightweight site
- [ ] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain:
  url:
  size:
  last_checked:
```

GTMetrix Report: N/A