### PR TITLE
Size of castorisdead.xyz changed.

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -500,8 +500,8 @@
 
 - domain: castorisdead.xyz
   url: https://castorisdead.xyz
-  size: 194
-  last_checked: 2022-12-12
+  size: 82.7
+  last_checked: 2022-12-30
 
 - domain: catdrout.xyz
   url: https://catdrout.xyz/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: castorisdead.xyz
  url: https://castorisdead.xyz/
  size: 82.7
  last_checked: 2022-12-30
```

GTMetrix Report: <https://gtmetrix.com/reports/castorisdead.xyz/TDRHEpne/>
