### PR TITLE
Add youtube-playlist-timer.mmap.page

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2978,6 +2978,11 @@
   size: 94.7
   last_checked: 2022-11-02
 
+- domain: youtube-playlist-timer.mmap.page
+  url: https://youtube-playlist-timer.mmap.page
+  size: 124
+  last_checked: 2023-04-27
+
 - domain: yuv.al
   url: https://yuv.al/
   size: 255


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: youtube-playlist-timer.mmap.page
  url: https://youtube-playlist-timer.mmap.page
  size: 124
  last_checked: 2023-04-27
```

GTMetrix Report: https://gtmetrix.com/reports/youtube-playlist-timer.mmap.page/71XNQ4mz/
