### PR TITLE
change piuvas.net size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2164,8 +2164,8 @@
 
 - domain: piuvas.net
   url: https://piuvas.net/
-  size: 19.4
-  last_checked: 2022-12-30
+  size: 16.6
+  last_checked: 2023-06-12
 
 - domain: pjals.vern.cc
   url: https://pjals.vern.cc/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: piuvas.net
  url: https://piuvas.net/
  size: 16.6
  last_checked: 2023-06-12
```

GTMetrix Report: https://gtmetrix.com/reports/piuvas.net/GijULppu/
