### PR TITLE
Update cujo.casa size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -740,8 +740,8 @@
 
 - domain: cujo.casa
   url: https://cujo.casa/
-  size: 55.4
-  last_checked: 2023-05-25
+  size: 28.4
+  last_checked: 2023-06-16
 
 - domain: culp.dev
   url: https://culp.dev/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: cujo.casa
  url: https://cujo.casa/
  size: 28.4
  last_checked: 2023-06-16
```

GTMetrix Report: https://gtmetrix.com/reports/cujo.casa/uECXh3Uc/
