### PR TITLE
Update size of probably.co.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2224,8 +2224,8 @@
 
 - domain: probably.co.uk
   url: https://probably.co.uk/
-  size: 47.3
-  last_checked: 2023-02-04
+  size: 73.4
+  last_checked: 2023-06-17
 
 - domain: processwire.dev
   url: https://processwire.dev/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: probably.co.uk
  url: https://probably.co.uk/
  size: 73.4
  last_checked: 2023-06-17
```

GTMetrix Report: https://gtmetrix.com/reports/probably.co.uk/oax1qX0f/
