### PR TITLE
Update reported size of colincogle.name

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -700,8 +700,8 @@
  
 - domain: colincogle.name
   url: https://colincogle.name/
-  size: 32.9
-  last_checked: 2023-05-19
+  size: 29.9
+  last_checked: 2023-07-07
 
 - domain: conorknowles.com
   url: https://conorknowles.com/


### PR DESCRIPTION
I figured out how to have even less to say, and made my homepage 3 KB smaller.  You can view the proof at [GTMetrix](https://gtmetrix.com/reports/colincogle.name/itXcMoLu/).  This commit updates the size and date on my entry in the `sites.yml` file.

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [X] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [X] I used the uncompressed size of the site
- [X] I have included a link to the GTMetrix report
- [X] The domain is in the correct alphabetical order
- [X] This site is not a ultra lightweight site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: colincogle.name
  url: https://colincogle.name
  size: 29.9
  last_checked: 2023-07-07
```

GTMetrix Report: https://gtmetrix.com/reports/colincogle.name/itXcMoLu/
