### PR TITLE
Update size for chino.is-a.dev

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -635,8 +635,8 @@
 
 - domain: chino.is-a.dev
   url: https://chino.is-a.dev/
-  size: 418
-  last_checked: 2023-02-01
+  size: 254
+  last_checked: 2023-08-01
 
 - domain: christianoliff.com
   url: https://christianoliff.com/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: chino.is-a.dev
  url: https://chino.is-a.dev/
  size: 254
  last_checked: 2023-08-01
```

GTMetrix Report: https://gtmetrix.com/reports/chino.is-a.dev/QnSA8q3P/
