### PR TITLE
Correct spelling of "declarations" in faq-04.html

### DIFF
--- a/_includes/faq-04.html
+++ b/_includes/faq-04.html
@@ -3,7 +3,7 @@
     <p>Many sites won't qualify for the 512KB Club, but there are some quick things you could try to reduce the size of
         your site:</p>
 
-    <p><b>1. Replace custom fonts with a local font stack by replacing your <code>font-family</code> declerations in
+    <p><b>1. Replace custom fonts with a local font stack by replacing your <code>font-family</code> declarations in
             your CSS to one of the following:</b></p>
     <pre><code># Sans-serif font stack
 font-family: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Nimbus Sans L", Roboto, Noto, "Segoe UI", Arial, Helvetica, "Helvetica Neue", sans-serif;


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [x] Website code changes (512kb.club site)
- [ ] Other not listed

----

The FAQ page currently reads, under "My site doesn't qualify, what can I do?":

> 1. Replace custom fonts with a local font stack by replacing your font-family declerations in your CSS to one of the following:

There's a typo, resulting in the mis-spelling of the word "declarations". This PR corrects it to:

> 1. Replace custom fonts with a local font stack by replacing your font-family declarations in your CSS to one of the following: