### PR TITLE
Add thomasvoss.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2897,6 +2897,11 @@
   size: 488
   last_checked: 2022-05-15
 
+- domain: thomasvoss.com
+  url: https://thomasvoss.com
+  size: 32.2
+  last_checked: 2023-08-15
+
 - domain: tianheg.xyz
   url: https://tianheg.xyz/
   size: 101


### PR DESCRIPTION
This PR is:

- [X] Adding a new domain

- [X] I used the uncompressed size of the site
- [X] I have included a link to the GTMetrix report
- [X] The domain is in the correct alphabetical order
- [X] This site is not a ultra lightweight site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: thomasvoss.com
  url: https://thomasvoss.com
  size: 32.2
  last_checked: 2023-08-15
```

GTMetrix Report: https://gtmetrix.com/reports/thomasvoss.com/b0oh6f6D/
