### PR TITLE
add miguelpimentel.do, update forgetful.dev

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1210,8 +1210,8 @@
 
 - domain: forgetful.dev
   url: https://forgetful.dev/
-  size: 74.3
-  last_checked: 2023-06-12
+  size: 406
+  last_checked: 2023-08-24
 
 - domain: format-express.dev
   url: https://format-express.dev/
@@ -1956,6 +1956,11 @@
   url: https://midnight.pub/
   size: 9.9
   last_checked: 2022-05-06
+
+- domain: miguelpimentel.do
+  url: https://miguelpimentel.do/
+  size: 88.1
+  last_checked: 2023-08-24
 
 - domain: mikebabb.com
   url: https://mikebabb.com/


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [x] Updating existing domain **size**
- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

_**I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content, and I attest that this site is neither of these things.**_

- [x] Check to confirm

### forgetful.dev (updated)

```yaml
- domain: forgetful.dev
  url: https://forgetful.dev/
  size: 406
  last_checked: 2023-08-24
```

GTMetrix Report: <https://gtmetrix.com/reports/forgetful.dev/nApKQDRE/>

### miguelpimentel.do (added)

```yaml
- domain: miguelpimentel.do
  url: https://miguelpimentel.do/
  size: 88.1
  last_checked: 2023-08-24
```

GTMetrix Report: <https://gtmetrix.com/reports/miguelpimentel.do/0UgTGEle/>
