### PR TITLE
Add plaintextsports.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2311,6 +2311,11 @@
   url: https://plaindrops.de/
   size: 27.1
   last_checked: 2022-02-21
+  
+- domain: plaintextsports.com
+  url: https://plaintextsports.com/
+  size: 21.9
+  last_checked: 2023-10-10
 
 - domain: plausible.io
   url: https://plausible.io/


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: plaintextsports.com
  url: https://plaintextsports.com/
  size: 21.9
  last_checked: 2023-10-10
```

GTMetrix Report: 
https://gtmetrix.com/reports/plaintextsports.com/VdAvPYFd/