### PR TITLE
Domain name change and size update for konstantintutsch.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1755,8 +1755,8 @@
 
 - domain: konstantintutsch.com
   url: https://konstantintutsch.com/
-  size: 73.7
-  last_checked: 2023-09-16
+  size: 72.0
+  last_checked: 2023-11-11
 
 - domain: kraktoos.com
   url: https://kraktoos.com/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1753,8 +1753,8 @@
   size: 197
   last_checked: 2022-03-12
 
-- domain: konstantintutsch.de
-  url: https://konstantintutsch.de/
+- domain: konstantintutsch.com
+  url: https://konstantintutsch.com/
   size: 73.7
   last_checked: 2023-09-16
 
@@ -2547,7 +2547,7 @@
   url: https://rb.ax/
   size: 5.51
   last_checked: 2023-11-10
-  
+
 - domain: rectangles.app
   url: https://rectangles.app/
   size: 6.93


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: konstantintutsch.com
  url: https://konstantintutsch.com/
  size: 72.0
  last_checked: 2023-11-11
```

GTMetrix Report: https://gtmetrix.com/reports/konstantintutsch.com/qmwxHEUW/
