### PR TITLE
changed sudocss.com to sudocss.vercel.app because I could not renew sudocss.com domain

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2923,8 +2923,8 @@
   size: 188
   last_checked: 2022-04-26
 
-- domain: sudocss.com
-  url: https://sudocss.com/
+- domain: sudocss.vercel.app
+  url: https://sudocss.vercel.app/
   size: 108
   last_checked: 2023-08-31
 


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: sudocss.vercel.app
  url: https://sudocss.vercel.app/
  size: 108
  last_checked: 2023-08-31
```

GTMetrix Report: https://gtmetrix.com/reports/sudocss.com/YllnTEAS/
