### PR TITLE
nmichaels.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -3537,3 +3537,8 @@
   url: https://zwbetz.com/
   size: 67.8
   last_checked: 2022-07-20
+
+- domain: www.nmichaels.org
+  url: https://www.nmichaels.org
+  size: 6.45
+  last_checked: 2023-12-22


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed


- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: www.nmichaels.org
  url: https://www.nmichaels.org
  size: 6.45
  last_checked: 2023-12-22
```

GTMetrix Report: https://gtmetrix.com/reports/www.nmichaels.org/u7puBs7p/

Note: I linked to the front page, but most useful stuff is on /scripts.py. That page is 6.64 k (https://gtmetrix.com/compare/u7puBs7p/fBBEBtN6), and links to around 86 k of other pages.