### PR TITLE
update sites.yml - add envs.net and creme.envs.net

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -823,6 +823,11 @@
   size: 360
   last_checked: 2022-04-26
 
+- domain: creme.envs.net
+  url: https://creme.envs.net/
+  size: 221
+  last_checked: 2023-12-29
+
 - domain: cri.dev
   url: https://cri.dev/
   size: 30.2
@@ -1147,6 +1152,11 @@
   url: https://enesergun.net
   size: 38.7
   last_checked: 2023-10-27
+
+- domain: envs.net
+  url: https://envs.net
+  size: 216
+  last_checked: 2023-12-29
 
 - domain: eportfoliot.redu.fi/eportfoliot/juusokekonen/
   url: https://eportfoliot.redu.fi/eportfoliot/juusokekonen/


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: creme.envs.net
  url: https://creme.envs.net/
  size: 221
  last_checked: 2023-12-29
```
..
```
- domain: envs.net
  url: https://envs.net
  size: 216
  last_checked: 2023-12-29
```

GTMetrix Report: 

*envs.net:*
https://gtmetrix.com/reports/envs.net/zJlb35y3/

*creme.envs.net:*
https://gtmetrix.com/reports/creme.envs.net/Kpz4IXjW/
