### PR TITLE
Updated size of nthp.me

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2301,7 +2301,7 @@
 - domain: nthp.me
   url: https://nthp.me
   size: 78.5
-  last_checked: 2023-12-29
+  last_checked: 2023-12-30
 
 - domain: obviy.us
   url: https://obviy.us/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2300,7 +2300,7 @@
 
 - domain: nthp.me
   url: https://nthp.me
-  size: 92.9
+  size: 78.5
   last_checked: 2023-12-29
 
 - domain: obviy.us


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [ ] Check to confirm

```
- domain: nthp.me
  url: https://nthp.me
  size: 78.5
  last_checked: 2023-12-30
```

GTMetrix Report: https://gtmetrix.com/reports/nthp.me/h2p0c1QV/
