### PR TITLE
changed 5am.is to petercammeraat.net

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -53,10 +53,10 @@
   size: 91.5
   last_checked: 2022-03-06
 
-- domain: 5am.is
-  url: https://5am.is
-  size: 30.0
-  last_checked: 2022-11-26
+- domain: petercammeraat.net
+  url: https://petercammeraat.net
+  size: 32.91
+  last_checked: 2024-01-16
 
 - domain: 60z.github.io
   url: https://60z.github.io/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra lightweight site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: petercammeraat.net
  url: https://petercammeraat.net
  size: 32.91
  last_checked: 2024-01-16
```

Cloudflare Report: 
https://radar.cloudflare.com/scan/c6fe110b-9b6d-4651-98fa-6953f165f89c/summary