### PR TITLE
Update danq.me from 481kb to 234kb

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -985,8 +985,8 @@
 
 - domain: danq.me
   url: https://danq.me/
-  size: 481
-  last_checked: 2023-08-02
+  size: 234
+  last_checked: 2024-03-22
 
 - domain: dariusz.wieckiewicz.org
   url: https://dariusz.wieckiewicz.org/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed


- [x] I used the uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

_**I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.**_

- [x] Check to confirm


```
- domain: danq.me
  url: https://danq.me/
  size: 234
  last_checked: 2024-03-22
```

Cloudflare Report: https://radar.cloudflare.com/scan/a618e431-7002-4618-8e4e-8f95f87b2ed9/summary

Article about how I reduced my homepage from 481kb to 234kb (without removing content) to get myself "up" a 512kb club bracket: https://danq.me/234kb