### PR TITLE
Update No BS Repairs

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2510,7 +2510,7 @@
 
 - domain: no-bs-repairs.com
   url: https://no-bs-repairs.com
-  size: 101
+  size: 219.29
   last_checked: 2023-07-23
 
 - domain: no-js.club


### PR DESCRIPTION
Got a bit larger to 219.29kb from 101kb

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: no-bs-repairs.com
  url: no-bs-repairs.com
  size: 219.29kb
  last_checked: June 17 2024
```

Cloudflare Report: https://radar.cloudflare.com/scan/249e30d8-593e-4283-8b91-995837ae6a69/summary
