### PR TITLE
Change size of fiala.space

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1395,8 +1395,8 @@
 
 - domain: fiala.space
   url: https://fiala.space/
-  size: 53.38
-  last_checked: 2024-05-31
+  size: 323.75
+  last_checked: 2024-06-23
 
 - domain: figcat.com
   url: https://figcat.com/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

For business reasons I had to change the design of the site and the front page now has a lot of images. Still qualifies for Blue team.

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: fiala.space
  url: https://fiala.space/
  size: 323.75
  last_checked: 2024-06-23
```

Cloudflare Report: https://radar.cloudflare.com/scan/585a90d2-62a8-40e5-86c8-cdeb10dbf12e/summary
