### PR TITLE
updated riedler.wien size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -3259,9 +3259,9 @@
   last_checked: 2023-12-07
 
 - domain: riedler.wien
-  url: http://riedler.wien/music/
-  size: 138
-  last_checked: 2022-08-17
+  url: https://riedler.wien/music/
+  size: 44.42
+  last_checked: 2024-09-27
 
 - domain: rishigoomar.com
   url: https://rishigoomar.com/


### PR DESCRIPTION

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!-- -->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the Cloudflare report 
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: riedler.wien
  url: https://riedler.wien/music/
  size: 44.42
  last_checked: 2024-09-27
```

Cloudflare Report: https://radar.cloudflare.com/scan/fc4b75ca-0098-4957-8e86-e34c1450512a/summary
note: the URL in the report contains an extra flag to circumvent my ban on chromium-based browsers, since cloudflare uses chromium to test websites. This flag isn't included in the data file because the ban would kick in on the next press of any sublinks anyway, confusing any potential visitors, as well as giving away the "secret" flag