### PR TITLE
Remove duplicate entry

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2028,11 +2028,6 @@
   size: 15.90
   last_checked: 2024-11-15
 
-- domain: jangobrecht.com
-  url: https://jangobrecht.com/
-  size: 15.90
-  last_checked: 2024-11-15
-
 - domain: janilowski.pl
   url: https://janilowski.pl/
   size: 70.89


### PR DESCRIPTION
Remove duplicate / double entry of jangobrecht.com

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [x] Other not listed