### PR TITLE
updated size of ficd.ca

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1590,8 +1590,8 @@
 
 - domain: ficd.ca
   url: https://ficd.ca/
-  size: 38.6
-  last_checked: 2024-09-24
+  size: 87.42
+  last_checked: 2025-02-17
 
 - domain: figcat.com
   url: https://figcat.com/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: ficd.ca
  url: https://ficd.ca/
  size: 87.42
  last_checked: 2025-02-17

```

Cloudflare Report: [](https://radar.cloudflare.com/scan/81cec37b-7ca4-42c8-a30d-e510db18d864)
