### PR TITLE
Reduce DanQ.me from 234kb to 191kb

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1140,8 +1140,8 @@
 
 - domain: danq.me
   url: https://danq.me/
-  size: 234
-  last_checked: 2024-03-22
+  size: 194
+  last_checked: 2025-03-18
 
 - domain: dariusz.wieckiewicz.org
   url: https://dariusz.wieckiewicz.org/


### PR DESCRIPTION
I've been making some font and CSS optimisations with an aim of being consistently small enough to hit 250kb.club; a side-effect is that I now rank "smaller" in 512kb.club too!

----

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed


- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: danq.me
  url: https://danq.me/
  size: 194
  last_checked: 2025-03-18
```

Cloudflare report: https://radar.cloudflare.com/scan/68005a5a-8363-4508-b658-78a3aa60b12f/summary  (shows 194.19kB)

![image](https://github.com/user-attachments/assets/cb7e3501-ec95-46e3-a50c-8ea5e7d6e161)
