### PR TITLE
Update mei.puppycat.house to 394kB

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2770,8 +2770,8 @@
 
 - domain: mei.puppycat.house
   url: https://mei.puppycat.house/
-  size: 485.51
-  last_checked: 2024-09-15
+  size: 394
+  last_checked: 2025-05-15
 
 - domain: melroy.org
   url: https://melroy.org


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

**-91kB**
Stopped including a _whole_ physics engine (-64kb), downscaled a few images to their actual display size, started inlining CSS (load times, probably slight +kB)

This PR is:

- [ ] Adding a new domain
- [X] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [X] I used the **exact** uncompressed size of the site
- [X] I have included a link to the Cloudflare report
- [X] This site is not an ultra minimal site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: mei.puppycat.house
  url: https://mei.puppycat.house/
  size: 394
  last_checked: 2025-05-15
```

Cloudflare Report: https://radar.cloudflare.com/scan/0ff33270-69bb-4e50-919e-6ea38797f541/summary
