### PR TITLE
Re-add ari.lt

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -263,6 +263,11 @@
   size: 342
   last_checked: 2025-08-03
 
+- domain: ari.lt
+  url: https://ari.lt/
+  size: 165
+  last_checked: 2025-08-28
+
 - domain: arkensys.dedyn.io
   url: https://arkensys.dedyn.io
   size: 19.56


### PR DESCRIPTION
Hello,

The old version of my website turned huge due to it being centralised into a single page resulting in a removal.

Now, after separation, it is back under 512kb. See <https://radar.cloudflare.com/scan/516ec0ec-a819-4c76-b499-a4253e453e58/summary>

Thanks!

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: ari.lt
  url: https://ari.lt/
  size: 165
  last_checked: 2025-08-28
```

Cloudflare Report: https://radar.cloudflare.com/scan/516ec0ec-a819-4c76-b499-a4253e453e58/summary
