### PR TITLE
chore: update dunkirk.sh's size

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1200,8 +1200,8 @@
 
 - domain: dunkirk.sh
   url: http://dunkirk.sh/
-  size: 135.24
-  last_checked: 2025-09-18
+  size: 89.17
+  last_checked: 2025-09-21
 
 - domain: duplitech.fr
   url: https://www.duplitech.fr/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: dunkirk.sh
  url: http://dunkirk.sh/
  size: 89.17
  last_checked: 2025-09-21
```

Cloudflare Report: https://radar.cloudflare.com/scan/39b90797-8d48-4549-9b27-aaa66315fc26/network
