### PR TITLE
Add freethedotye.org (42KB)

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -4512,3 +4512,8 @@
   url: https://zwieratko.sk/
   size: 30.94
   last_checked: 2025-05-18
+
+  - domain: freethedotye.org
+  url: https://freethedotye.org/
+  size: 42
+  last_checked: 2025-10-07


### PR DESCRIPTION

Adding freethedotye.org to the 512KB Club. This campaign website focuses on the .YE top-level domain (TLD), featuring a blog with articles on related topics and a correspondence section for communications, all optimized to load quickly on low-bandwidth connections such as those in Yemen.

Cloudflare Radar scan results: https://radar.cloudflare.com/scan/0c6f4cf0-e1dd-4627-a950-994ba6d19a40/summary

Total uncompressed size: 42KB (checked 2025-10-07). The site loads efficiently and stays well under the limit.

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: freethedotye.org
  url: https://freethedotye.org/
  size: 42
  last_checked: 2025-10-07
```

Cloudflare Report: https://radar.cloudflare.com/scan/0c6f4cf0-e1dd-4627-a950-994ba6d19a40/summary
