### PR TITLE
Update site size for probably.co.uk

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -3195,8 +3195,8 @@
 
 - domain: probably.co.uk
   url: https://probably.co.uk/
-  size: 67.15
-  last_checked: 2025-05-18
+  size: 68.75
+  last_checked: 2025-10-22
 
 - domain: processwire.dev
   url: https://processwire.dev/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [X] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [X] I used the **exact** uncompressed size of the site
- [X] I have included a link to the Cloudflare report
- [X] This site is not an ultra minimal site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: probably.co.uk
  url: https://probably.co.uk/
  size: 68.75
  last_checked: 2025-10-22
```

Cloudflare Report: https://radar.cloudflare.com/scan/25363007-649c-4978-843d-85d1e34e3673/network
