### PR TITLE
Add ser1.net

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -4342,3 +4342,8 @@
   url: https://zwieratko.sk/
   size: 30.94
   last_checked: 2025-08-30
+
+- domain: ser1.net
+  url: https://ser1.net/
+  size: 206
+  last_checked: 2025-11-07


### PR DESCRIPTION
This PR is:

- [X] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

- [X] I used the **exact** uncompressed size of the site
- [X] I have included a link to the Cloudflare report
- [X] This site is not an ultra minimal site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: ser1.net
  url: https://ser1.net/
  size: 206
  last_checked: 2025-11-07
```

Cloudflare Report: 
https://radar.cloudflare.com/scan/1976fa00-e744-4a85-918f-6ae5201af1f0/summary


The (entire) site uses no Javascript (excepting the photo gallery, which is PhotoPrism), and all interactivity is accomplished with CSS. The blog page is more interesting, but I saw no other examples of linking to sub-pages. The blog page tops out at 257K.

The resume is also interactive and accomplished with CSS only, but it does embed an SVG of my formatted resume which at 4 uncompressed pages is 1.7MB. The entire web site -- including blogs and images -- is 9.5MB: 6.5MB in images (in blogs), 1.4MB CSS; 1.2M in 150 blog entries dating back to 2009.