### PR TITLE
Add emulationonline.com to sites.yml

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1268,6 +1268,11 @@
   size: 404.65
   last_checked: 2025-08-30
 
+- domain: emulationonline.com
+  url: https://emulationonline.com
+  size: 16.0
+  last_checked: 2025-11-07
+
 - domain: enattendantpauline.ca
   url: https://www.enattendantpauline.ca/
   size: 103.87


### PR DESCRIPTION
My retro computing blog. 16kb per cloudflare radar: https://radar.cloudflare.com/scan/000889e9-94d1-4440-8615-3f2abba1e3de/summary

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain:
  url:
  size:
  last_checked:
```

Cloudflare Report: https://radar.cloudflare.com/scan/000889e9-94d1-4440-8615-3f2abba1e3de/summary
