### PR TITLE
Add percentagecalculator.page to the 512KB Club

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,8 @@
+- domain: percentagecalculator.page
+  url: https://percentagecalculator.page/
+  size: 73.00
+  last_checked: 2025-11-07
+  
 - domain: 0xedward.io
   url: https://0xedward.io/
   size: 41.02


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: percentagecalculator.page
  url: https://percentagecalculator.page/
  size: 73.00
  last_checked: 2025-11-07
```

Cloudflare Report:  https://radar.cloudflare.com/scan/80ce52e4-1d59-40d6-bb9c-a918064ffc85/summary
