### PR TITLE
Adds philna.sh to the orange team

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -4407,3 +4407,8 @@
   url: https://zwieratko.sk/
   size: 30.94
   last_checked: 2025-08-30
+  
+- domain: philna.sh
+  url: https://philna.sh/
+  size: 198
+  last_checked: 2025-11-27


### PR DESCRIPTION
Please find the Cloudflare scan here: https://radar.cloudflare.com/scan/d63ceaaa-644c-4448-a07f-1d452791a057/summary

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [ ] Check to confirm

```
- domain: philna.sh
  url: https://philna.sh/
  size: 198
  last_checked: 2025-11-27
```

Cloudflare Report: https://radar.cloudflare.com/scan/d63ceaaa-644c-4448-a07f-1d452791a057/summary
