### PR TITLE
Fix url typo for captnemo.in

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -749,7 +749,7 @@
   last_checked: 2025-08-30
 
 - domain: captnemo.in
-  url: htts://captnemo.in
+  url: https://captnemo.in
   size: 8.3
   last_checked: 2025-08-19
 


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [x] Other not listed
   - typo, it said `htts` instead of `https`
   - i did not change anything other than that