### PR TITLE
Add staniforth.org.uk to 512KB Club

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,8 @@
+- domain: staniforth.org.uk
+  url: https://staniforth.org.uk/
+  size: 41.00
+  last_checked: 2026-01-06
+
 - domain: 0xedward.io
   url: https://0xedward.io/
   size: 41.02


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [X] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [X] I used the **exact** uncompressed size of the site
- [X] I have included a link to the Cloudflare report
- [ ] This site is not an ultra minimal site
- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [X] Check to confirm

```
- domain: staniforth.org.uk
  url: https://staniforth.org.uk/
  size: 41.00
  last_checked: 2026-01-06
```

Cloudflare Report: https://radar.cloudflare.com/scan/433edfc3-172d-461c-9df5-560d43b93494
