### PR TITLE
adds penfield.ily.rs

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,8 @@
+- domain: penfield.ily.rs
+  url: https://penfield.ily.rs
+  size: 0.35
+  last_checked: 2026-01-22
+
 - domain: 0xedward.io
   url: https://0xedward.io/
   size: 41.02


### PR DESCRIPTION
This site is definitely minimal, but it currently does everything it was supposed to, so I'd only be adding more to it for the sake of it at this point, which feels like it defeats the point of the club! 

It's my version of the Penfield Mood Organ from Electric Sheep. On the hour every hour a new chime happens, and the page is re-randomized to dial a different number on the Penfield, and give a different mood.

The precise number of bytes is a little difficult because there's SSR randomness and an incrementing "ring counter". 350 bytes is the current maximum if the longest introduction and longest mood are selected for that hour. The average is more like 250.

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: penfield.ily.rs
  url: https://penfield.ily.rs
  size: 0.35
  last_checked: 2026-01-22
```

Cloudflare Report: https://radar.cloudflare.com/scan/9ddf7f04-c97b-4722-9d65-02e5961ff5a5/summary
