### PR TITLE
update size for envs.net and creme.envs.net

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -945,8 +945,8 @@
 
 - domain: creme.envs.net
   url: https://creme.envs.net/
-  size: 200.57
-  last_checked: 2025-08-30
+  size: 57
+  last_checked: 2026-01-29
 
 - domain: cri.cl
   url: https://cri.cl/
@@ -1360,8 +1360,8 @@
 
 - domain: envs.net
   url: https://envs.net
-  size: 224.96
-  last_checked: 2025-08-30
+  size: 139
+  last_checked: 2026-01-29
 
 - domain: eorus.com
   url: http://eorus.com/


### PR DESCRIPTION
This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [ ] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: creme.envs.net
  url: https://creme.envs.net/
  size: 57
  last_checked: 2026-01-29
- domain: envs.net
  url: https://envs.net
  size: 139
  last_checked: 2026-01-29
```

Cloudflare Report's: 
creme.envs.net: https://radar.cloudflare.com/scan/358c4138-2a04-42c0-8def-a0627df509c0
envs.net: https://radar.cloudflare.com/scan/ce655528-ee2b-48be-9797-b77bf2088922