### PR TITLE
Update size for notes.hatedabamboo.me

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -2950,8 +2950,8 @@
 
 - domain: notes.hatedabamboo.me
   url: https://notes.hatedabamboo.me/
-  size: 83
-  last_checked: 2025-09-17
+  size: 44
+  last_checked: 2026-02-11
 
 - domain: notes.musayev.com
   url: https://notes.musayev.com/


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the **exact** uncompressed size of the site
- [x] I have included a link to the Cloudflare report
- [x] This site is not an ultra minimal site
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: notes.hatedabamboo.me
  url: https://notes.hatedabamboo.me/
  size: 44
  last_checked: 2026-02-11
```

Cloudflare Report: https://radar.cloudflare.com/scan/09ff934f-b9d0-4ec5-9304-b2ce81f571c1/summary
